### PR TITLE
analysis-icu プラグインを追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM elasticsearch:2.4.1
 
 # Install the kuromoji
 RUN /usr/share/elasticsearch/bin/plugin install \
+    analysis-icu \
     analysis-kuromoji \
     lmenezes/elasticsearch-kopf
 


### PR DESCRIPTION
## 概要

* analysis-icu をインストールして、使えるようにします
* 本番環境系 (staging, preview 含む) ではすでに利用可能に設定されてるものです
* ワーカー検索でこのプラグインを活用したいので、こちらの Docker イメージの方でも使えるようにしておきたい次第
