### PR TITLE
Fix the command for installing plugins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
 FROM elasticsearch:2.4.1
 
-# Install the kuromoji
-RUN /usr/share/elasticsearch/bin/plugin install \
-    analysis-icu \
-    analysis-kuromoji \
-    lmenezes/elasticsearch-kopf
+# Install the plugins
+RUN plugin install analysis-icu && \
+    plugin install analysis-kuromoji && \
+    plugin install lmenezes/elasticsearch-kopf
 
 COPY config/elasticsearch.yml /usr/share/elasticsearch/config


### PR DESCRIPTION
It is necessary to call `plugin install` command for each plug-in.
