### PR TITLE
Snapshot APIでバックアップできるよう設定

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,3 +6,6 @@ RUN plugin install analysis-icu && \
     plugin install lmenezes/elasticsearch-kopf
 
 COPY config/elasticsearch.yml /usr/share/elasticsearch/config
+
+RUN mkdir -p /var/opt/elasticsearch/backups && \
+    chown -R elasticsearch:elasticsearch /var/opt/elasticsearch

--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -1,2 +1,3 @@
 network.host: 0.0.0.0
 script.inline: true
+path.repo: ["/var/opt/elasticsearch/backups"]


### PR DESCRIPTION
あらかじめ書き込み可能なディレクトリを作成しておく必要があるため。
併せてpath.repoも設定。
